### PR TITLE
Make it more obvious how to get the current time

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -35,10 +35,6 @@ time = { version = "0.3", features = ["macros"] }
 2. **Get the current time** With the crate feature `std` a UTC offset
 ([`OffsetDateTime`](https://docs.rs/time/latest/time/struct.OffsetDateTime.html)) is available,
 but with the crate feature `local-offset`, we can also get the local time.
-The time is retrieved from a [non-monotonic](https://stackoverflow.com/a/41203566/5964129)
-[`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) or from a
-ECMAScript [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)
-on WebAssembly.
 
 ```rust
 use time::OffsetDateTime;

--- a/src/index.md
+++ b/src/index.md
@@ -32,7 +32,25 @@ This short tutorial describes basic usage of `time`, to get operational quickly.
 time = { version = "0.3", features = ["macros"] }
 ```
 
-2. **Create dates and times.** We can create dates
+2. **Get the current time** With the `std` features a UTC offset
+([`OffsetDateTime`](https://docs.rs/time/latest/time/struct.OffsetDateTime.html)) wrapping is available,
+but with the crate feature `local-offset`, we can also get the local time.
+
+The time is retrieved from a non-monotonic
+[`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) or from a
+ECMAScript [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)
+on WebAssembly.
+
+```rust
+use time::OffsetDateTime;
+
+let now = OffsetDateTime::now_utc();
+// let local = OffsetDateTime::now_local();
+
+println!("{now}");
+```
+
+3. **Create dates and times.** We can create dates
 ([`Date`](https://docs.rs/time/latest/time/struct.Date.html)),
 dates with times
 ([`PrimitiveDateTime`](https://docs.rs/time/latest/time/struct.PrimitiveDateTime.html))
@@ -65,7 +83,7 @@ println!("{date}, {datetime}, {datetime_off}");
 // 2022-01-01, 2022-01-01 13:00:55.0, 2022-01-01 13:00:55.0 +01:02:03
 ```
 
-3. **Manipulate dates and use
+4. **Manipulate dates and use
 [`Duration`s](https://time-rs.github.io/api/time/struct.Duration.html)**:
 ```rust
 use time::Duration;

--- a/src/index.md
+++ b/src/index.md
@@ -32,11 +32,10 @@ This short tutorial describes basic usage of `time`, to get operational quickly.
 time = { version = "0.3", features = ["macros"] }
 ```
 
-2. **Get the current time** With the `std` features a UTC offset
-([`OffsetDateTime`](https://docs.rs/time/latest/time/struct.OffsetDateTime.html)) wrapping is available,
+2. **Get the current time** With the crate feature `std` a UTC offset
+([`OffsetDateTime`](https://docs.rs/time/latest/time/struct.OffsetDateTime.html)) is available,
 but with the crate feature `local-offset`, we can also get the local time.
-
-The time is retrieved from a non-monotonic
+The time is retrieved from a [non-monotonic](https://stackoverflow.com/a/41203566/5964129)
 [`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) or from a
 ECMAScript [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)
 on WebAssembly.


### PR DESCRIPTION
I was kinda struggling to find this, especially because it's so prominent with other similar crates.
Because it wasn't mentioned in the docs directly, I thought I might have to create a timestamp using `SystemTime::now()` or `Instant::now()` myself, but then I couldn't figure out how to convert these to types that `time` uses.

I only found out because other people had the same problem:
- [How do I get current time and/or current datetime using time create ? ](https://github.com/time-rs/time/discussions/520) #520
- [How to assign to a new variable the current time using time::PrimitiveDateTime type?](https://github.com/time-rs/time/discussions/507) #507

In other documentation texts with a similar scope, this information is also presented more prominently:
- [`chrono`](https://crates.io/crates/chrono#:~:text=You%20can%20get%20the%20current%20date%20and%20time%20in%20the%20UTC%20time%20zone%20(Utc%3A%3Anow())%20or%20in%20the%20local%20time%20zone%20(Local%3A%3Anow()).)
- [MDN js Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#several_ways_to_create_a_date_object)
- [Dart Datetime](https://api.dart.dev/stable/2.18.4/dart-core/DateTime-class.html#:~:text=For%20example%3A-,final%20now%20%3D%20DateTime.now()%3B,-final%20berlinWallFell%20%3D)