### PR TITLE
Fix link to twitter bug

### DIFF
--- a/src/api/format-description.md
+++ b/src/api/format-description.md
@@ -195,7 +195,7 @@ present in the above diagram.
 
   There are two bases for the year: _calendar_ and _iso\_week_. The former is what you want if using
   the month, day, ordinal, or similar. You likely only want to use `iso_week` if you are using the
-  week number with `repr:iso`. [Don't be like Twitter](twitter-bug); know which should be used when.
+  week number with `repr:iso`. [Don't be like Twitter][twitter-bug]; know which should be used when.
 
   Users have the option to choose whether the sign is _automatic_ (the default) or _mandatory_.
   If the sign is automatic, it will only be present when the value is negative _or_ if the


### PR DESCRIPTION
On the [Format Description](https://time-rs.github.io/book/api/format-description.html) page, the "Don't be like Twitter" link is broken. This fixes it by changing the markdown to a reference link.